### PR TITLE
Separated networkmessages

### DIFF
--- a/src/components/common.rs
+++ b/src/components/common.rs
@@ -3,8 +3,7 @@ use bevy_ecs::query::QueryData;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
 
-#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug)]
-#[derive(Hash)]
+#[derive(Component, Serialize, Deserialize, Clone, Copy, Debug, Hash)]
 pub struct Id(pub u128);
 
 #[derive(Component, Serialize, Deserialize, Default, Clone, Copy, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod util;
 
 use crate::network::net_manage::{Communication, start_tcp_task, start_udp_task};
 use crate::network::net_system::{tcp_net_receive, tcp_net_send, udp_net_receive, udp_net_send};
+use crate::network::net_tasks::{build_connection_messages, handle_udp_message};
 use bevy_ecs::prelude::*;
 use bincode::{Decode, Encode};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -12,7 +13,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::net::TcpStream;
 use tokio::{io, sync::mpsc};
-use crate::network::net_tasks::{build_connection_messages, handle_udp_message};
 
 #[derive(Resource)]
 struct FixedTime {
@@ -29,6 +29,7 @@ async fn main() -> io::Result<()> {
     let (tcp_receive_tx, tcp_receive_rx) = mpsc::channel::<(Vec<u8>, Arc<TcpStream>)>(1_000);
 
     let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 4444);
+    println!("Server starting; listening on 0.0.0.0:4444...");
 
     start_tcp_task(addr, tcp_send_rx, tcp_receive_tx).await?;
     start_udp_task(addr, udp_send_rx, udp_receive_tx, 8).await?;
@@ -41,6 +42,7 @@ async fn main() -> io::Result<()> {
         tcp_send_tx,
         tcp_receive_rx,
     ));
+    
     world.insert_resource(FixedTime {
         timestep: Duration::from_secs_f64(1.0 / 60.0),
         accumulator: Duration::ZERO,

--- a/src/network/net_encoding.rs
+++ b/src/network/net_encoding.rs
@@ -1,10 +1,8 @@
 use crate::components::common::Position;
 use crate::components::entity::Entity;
 use crate::components::player::PlayerBundle;
-use crate::network::net_message::NetworkMessageType;
+use crate::network::net_message::UDP;
 use bincode::config;
-use bincode::config::Configuration;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[test]
@@ -26,9 +24,9 @@ fn encode() -> Vec<u8> {
         (Entity::new(1), Position::new(0.0, 0.0)),
     ];
 
-    let msg: Vec<NetworkMessageType> = vec![
-        NetworkMessageType::Players { players },
-        NetworkMessageType::Entities { entities },
+    let msg: Vec<UDP> = vec![
+        UDP::Players { players },
+        UDP::Entities { entities },
     ];
 
     let buf = bincode::serde::encode_to_vec(msg, config::standard()).unwrap();
@@ -38,7 +36,7 @@ fn encode() -> Vec<u8> {
     buf
 }
 
-fn decode(buf: Vec<u8>) -> Vec<NetworkMessageType> {
+fn decode(buf: Vec<u8>) -> Vec<UDP> {
     bincode::serde::decode_from_slice(&buf, config::standard())
         .unwrap()
         .0

--- a/src/network/net_message.rs
+++ b/src/network/net_message.rs
@@ -1,15 +1,14 @@
 use crate::components::common::{Id, Position};
 use crate::components::entity::Entity;
 use crate::components::player::PlayerBundle;
-use crate::network::net_message::NetworkMessageType::Sequence;
-use bevy_ecs::prelude::{Commands, Component, Query, With};
+use bevy_ecs::prelude::Component;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::ops::Index;
-use crate::network::net_manage::{Connection, TcpConnection};
+
+pub trait NetworkMessageType {}
 
 #[derive(Component, Serialize, Deserialize, Clone, Debug)]
-pub struct NetworkMessage(pub NetworkMessageType);
+pub struct NetworkMessage<T: NetworkMessageType>(pub T);
 
 #[derive(Component)]
 pub struct UdpMessage;
@@ -20,7 +19,7 @@ pub struct TcpMessage;
 pub type SequenceNumber = u32;
 pub type BitMask = u8;
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub enum NetworkMessageType {
+pub enum UDP {
     Sequence {
         sequence_number: SequenceNumber,
     },
@@ -37,6 +36,16 @@ pub enum NetworkMessageType {
         keymask: BitMask,
         player_id: u128,
     },
+}
+
+impl NetworkMessageType for UDP {}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum TCP {
+    TextMessage {
+        message: String,
+        // Time stamp probably
+    },
     Join {
         lobby_id: u128,
     },
@@ -44,3 +53,5 @@ pub enum NetworkMessageType {
         player_uid: u128,
     },
 }
+
+impl NetworkMessageType for TCP {}

--- a/src/network/net_system.rs
+++ b/src/network/net_system.rs
@@ -1,11 +1,11 @@
 use crate::Communication;
-use crate::network::net_manage::{Connection, TcpConnection, Packet};
+use crate::network::net_manage::{Connection, Packet, TcpConnection};
+use crate::network::server::server_join::handle_join;
 use bevy_ecs::change_detection::ResMut;
 use bevy_ecs::prelude::{Commands, Query};
 use bincode::config;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc::error::{TryRecvError, TrySendError};
-use crate::network::server::server_join::handle_join;
 
 pub fn udp_net_receive(
     mut comm: ResMut<Communication>,
@@ -16,14 +16,18 @@ pub fn udp_net_receive(
         match comm.udp_rx.try_recv() {
             Ok((bytes, addr)) => {
                 let c = connections.iter_mut().find(|x| x.ip_addrs == addr);
-                
+
                 match c {
                     Some(mut c) => {
-                        c.input_packet_buffer.push_back(Packet{bytes: bytes.clone()});
-                    },
+                        c.input_packet_buffer.push_back(Packet {
+                            bytes: bytes.clone(),
+                        });
+                    }
                     None => {
                         let mut conn = Connection::new(addr);
-                        conn.input_packet_buffer.push_back(Packet{bytes: bytes.clone()});
+                        conn.input_packet_buffer.push_back(Packet {
+                            bytes: bytes.clone(),
+                        });
                         commands.spawn(conn);
                     }
                 }
@@ -34,17 +38,14 @@ pub fn udp_net_receive(
     }
 }
 
-pub fn udp_net_send(
-    comm: ResMut<Communication>,
-    mut connections: Query<&mut Connection>,
-) {
+pub fn udp_net_send(comm: ResMut<Communication>, mut connections: Query<&mut Connection>) {
     for mut c in connections.iter_mut() {
         if c.output_message.is_empty() {
             continue;
         }
-        
+
         let message = bincode::serde::encode_to_vec(&c.output_message, config::standard()).unwrap();
-        
+
         match comm.udp_tx.try_send((message.clone(), c.ip_addrs)) {
             Ok(()) => {
                 c.output_message.clear();
@@ -58,7 +59,7 @@ pub fn udp_net_send(
 pub fn tcp_net_receive(
     mut commands: Commands,
     mut connections: Query<&mut TcpConnection>,
-    mut comm: ResMut<Communication>
+    mut comm: ResMut<Communication>,
 ) {
     // TODO: There should be a global lobby hashmap that will hold a bunch of these hashsets, and then figure out a way to work with that
     // Hashset of all player uuid's in lobby
@@ -67,16 +68,22 @@ pub fn tcp_net_receive(
     while !comm.tcp_rx.is_empty() {
         match comm.tcp_rx.try_recv() {
             Ok((bytes, stream)) => {
-                let c = connections.iter_mut().find(|x| { same_stream(&*x.stream, &*stream) });
-                
+                let c = connections
+                    .iter_mut()
+                    .find(|x| same_stream(&*x.stream, &*stream));
+
                 match c {
                     Some(mut c) => {
-                        c.input_packet_buffer.push_back(Packet{ bytes: bytes.clone() });
+                        c.input_packet_buffer.push_back(Packet {
+                            bytes: bytes.clone(),
+                        });
                         handle_join(&mut c, &bytes, &mut commands);
                     }
                     None => {
                         let mut conn = TcpConnection::new(stream);
-                        conn.input_packet_buffer.push_back(Packet{ bytes: bytes.clone() });
+                        conn.input_packet_buffer.push_back(Packet {
+                            bytes: bytes.clone(),
+                        });
                         handle_join(&mut conn, &bytes, &mut commands);
                         commands.spawn(conn);
                     }
@@ -88,23 +95,17 @@ pub fn tcp_net_receive(
     }
 }
 
-pub fn tcp_net_send(
-    comm: ResMut<Communication>,
-    mut connections: Query<&mut TcpConnection>,
-) {
+pub fn tcp_net_send(comm: ResMut<Communication>, mut connections: Query<&mut TcpConnection>) {
     for mut c in connections.iter_mut() {
         if c.output_message.is_empty() {
             continue;
         }
-        
+
         let message = bincode::serde::encode_to_vec(&c.output_message, config::standard()).unwrap();
-        
-        let x = comm
-            .tcp_tx
-            .try_send((message.clone(), c.stream.clone()));
-        
-        match x
-        {
+
+        let x = comm.tcp_tx.try_send((message.clone(), c.stream.clone()));
+
+        match x {
             Ok(()) => {
                 c.output_message.clear();
             }

--- a/src/network/net_tasks.rs
+++ b/src/network/net_tasks.rs
@@ -1,14 +1,13 @@
-use std::cmp::min;
-use std::collections::HashMap;
-use bevy_ecs::change_detection::DetectChanges;
 use crate::components::common::{Id, Position};
+use crate::components::player::PlayerBundle;
 use crate::network::net_manage::Connection;
-use crate::network::net_message::NetworkMessageType::Sequence;
+use crate::network::net_message::{NetworkMessage, UDP};
 use crate::network::server::player_input::handle_input;
+use bevy_ecs::change_detection::DetectChanges;
 use bevy_ecs::prelude::{Query, Ref};
 use bincode::config;
-use crate::components::player::PlayerBundle;
-use crate::network::net_message::{NetworkMessage, NetworkMessageType};
+use std::cmp::min;
+use std::collections::HashMap;
 
 const MESSAGE_PER_TICK_MAX: usize = 20;
 
@@ -20,39 +19,44 @@ pub fn handle_udp_message(
         for _ in 0..min(MESSAGE_PER_TICK_MAX, c.input_packet_buffer.len()) {
             match c.input_packet_buffer.pop_front() {
                 Some(p) => {
-                    let decoded: (Vec<NetworkMessageType>, usize) =
+                    let decoded: (Vec<UDP>, usize) =
                         bincode::serde::decode_from_slice(&p.bytes, config::standard()).unwrap();
 
                     let mut seq_num = None;
 
                     for m in decoded.0.iter() {
                         match m {
-                            Sequence { sequence_number } => {
+                            UDP::Sequence { sequence_number } => {
                                 seq_num = Some(sequence_number);
                             }
                             _ => {}
                         }
                     }
 
-                    if seq_num.is_none() { return; };
+                    if seq_num.is_none() {
+                        return;
+                    };
 
                     for m in decoded.0.iter() {
                         match m {
-                            NetworkMessageType::Input { keymask, player_id } => {
+                            UDP::Input { keymask, player_id } => {
                                 handle_input(*keymask, *player_id, &mut players);
                             }
-                            NetworkMessageType::Join { .. } => {}
                             _ => {}
                         }
                     }
 
-                    c.output_message.push(NetworkMessage(Sequence { sequence_number: *seq_num.unwrap() }));
+                    c.output_message.push(NetworkMessage(UDP::Sequence {
+                        sequence_number: *seq_num.unwrap(),
+                    }));
                 }
                 None => {}
             }
         }
-        
-        if !c.input_packet_buffer.is_empty() { c.input_packet_buffer.clear() }
+
+        if !c.input_packet_buffer.is_empty() {
+            c.input_packet_buffer.clear()
+        }
     }
 }
 
@@ -62,11 +66,14 @@ pub fn build_connection_messages(
 ) {
     let all_positions: HashMap<u128, PlayerBundle> = players
         .iter()
-        .filter(|(_, p)| { p.is_changed() })
-        .map(|(i, p)| (i.0, PlayerBundle{position: *p}))
+        .filter(|(_, p)| p.is_changed())
+        .map(|(i, p)| (i.0, PlayerBundle { position: *p }))
         .collect();
-    
+
     for mut c in connections.iter_mut() {
-        c.output_message.push(NetworkMessage(NetworkMessageType::Players { players: all_positions.clone() }));
+        c.output_message
+            .push(NetworkMessage(UDP::Players {
+                players: all_positions.clone(),
+            }));
     }
 }

--- a/src/network/server/player_input.rs
+++ b/src/network/server/player_input.rs
@@ -2,13 +2,9 @@ use crate::components::common::{Id, Position};
 use crate::network::net_message::BitMask;
 use bevy_ecs::prelude::Query;
 
-pub fn handle_input(
-    keymask: BitMask,
-    playerid: u128,
-    players: &mut Query<(&Id, &mut Position)>,
-) {
+pub fn handle_input(keymask: BitMask, playerid: u128, players: &mut Query<(&Id, &mut Position)>) {
     let move_speed = 0.1;
-    
+
     for (id, mut pos) in players.iter_mut() {
         if id.0 == playerid {
             if keymask & 1 > 0 {
@@ -26,4 +22,3 @@ pub fn handle_input(
         }
     }
 }
-

--- a/src/network/server/server_join.rs
+++ b/src/network/server/server_join.rs
@@ -1,40 +1,30 @@
 use crate::components::common::{Id, Position};
 use crate::components::player::PlayerBundle;
-use crate::network::net_message::NetworkMessageType::PlayerId;
-use crate::network::net_message::{NetworkMessage, NetworkMessageType};
+use crate::network::net_manage::TcpConnection;
+use crate::network::net_message::{NetworkMessage, TCP};
 use bevy_ecs::prelude::Commands;
 use bincode::config;
 use uuid::Uuid;
-use crate::network::net_manage::TcpConnection;
 
-pub fn handle_join(
-    connection: &mut TcpConnection,
-    bytes: &Vec<u8>,
-    commands: &mut Commands,
-) {
-    let decoded: (Vec<NetworkMessageType>, usize) =
+pub fn handle_join(connection: &mut TcpConnection, bytes: &Vec<u8>, commands: &mut Commands) {
+    let decoded: (Vec<TCP>, usize) =
         bincode::serde::decode_from_slice(bytes, config::standard()).unwrap();
-    let mut lid = 0;
     for m in decoded.0 {
         match m {
-            NetworkMessageType::Join { lobby_id } => {
-                lid = lobby_id;
+            TCP::Join { lobby_id } => {
+                println!("Trying to join lobby: {:?}", lobby_id);
+                // Generate an ID
+                let player_id = Uuid::new_v4().as_u128();
+
+                commands.spawn((PlayerBundle::new(Position::new(0.0, 0.0)), Id(player_id)));
+
+                println!("Player joined:  {:?}", player_id);
+
+                connection.output_message.push(NetworkMessage(TCP::PlayerId {
+                    player_uid: player_id,
+                }));
             }
             _ => {}
         }
     }
-
-    println!("Trying to join lobby: {:?}", lid);
-
-    // Generate an ID
-    let player_id = Uuid::new_v4().as_u128();
-
-    commands.spawn((
-        PlayerBundle::new(Position::new(0.0, 0.0)),
-        Id(player_id)
-    ));
-
-    println!("Player joined:  {:?}", player_id);
-    
-    connection.output_message.push(NetworkMessage(PlayerId { player_uid: player_id }));
 }


### PR DESCRIPTION
Separated NetMessageType into UDP and TCP and made NetworkMessage refer to a generic of those types.